### PR TITLE
aqua: fixup property syntax

### DIFF
--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -159,7 +159,7 @@ on property:ro.boot.usbconfig=0 && property:sys.usb.configfs=1
 
 on property:sys.usb.ffs.ready=1 && property:ro.boot.usbconfig=0 && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/UDC "none"
-    write /config/usb_gadget/g1/strings/0x409/serialnumber $ro.serialno
+    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb_acm"
     write /config/usb_gadget/g1/idProduct 0x2006
     symlink /config/usb_gadget/g1/functions/mass_storage.usb0 /config/usb_gadget/g1/configs/b.1/f1


### PR DESCRIPTION
 * host_init_verifier: Command 'write /config/usb_gadget/g1/strings/0x409/serialnumber $ro.serialno' (device/realme/aqua/rootdir/etc/init.target.rc:162) failed: using deprecated syntax for specifying property 'ro.serialno', use ${name} instead